### PR TITLE
Removed deprecated "device_state_attributes"

### DIFF
--- a/custom_components/cryptoinfo/sensor.py
+++ b/custom_components/cryptoinfo/sensor.py
@@ -106,7 +106,7 @@ class CryptoinfoSensor(Entity):
         return self._unit_of_measurement
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {ATTR_LAST_UPDATE: self._last_update, ATTR_VOLUME: self._volume, ATTR_CHANGE: self._change, ATTR_MARKET_CAP: self._market_cap }
 
     def _update(self):


### PR DESCRIPTION
`device_state_attributes` is deprecated and replaced by `extra_state_attributes`.

Warning will be logged  from 2021.12 and functionality will be removed in 2022.4