### PR TITLE
Add simple price fetching with config and fallback for main fetch

### DIFF
--- a/custom_components/cryptoinfo/const/const.py
+++ b/custom_components/cryptoinfo/const/const.py
@@ -6,6 +6,7 @@ CONF_CURRENCY_NAME = "currency_name"
 CONF_MULTIPLIER = "multiplier"
 CONF_UPDATE_FREQUENCY = "update_frequency"
 CONF_UNIT_OF_MEASUREMENT = "unit_of_measurement"
+CONF_USE_SIMPLE_PRICE = "use_simple_price"
 
 SENSOR_PREFIX = "Cryptoinfo "
 ATTR_LAST_UPDATE = "last_update"


### PR DESCRIPTION
You might not like this one but it's working well for my needs given the API endpoint is still disabled :)

Adds a `use_simple_price` config option to use one of the basic price endpoints, and also uses that as a fallback for the main fetch if it fails